### PR TITLE
Change damage source to kinetic death

### DIFF
--- a/src/main/java/com/kssjw/kineticminecart/util/CartImpactUtil.java
+++ b/src/main/java/com/kssjw/kineticminecart/util/CartImpactUtil.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.level.Level;
 
 public class CartImpactUtil {
@@ -37,6 +38,14 @@ public class CartImpactUtil {
     }
 
     public static void tryKill(Entity target, float speed) {
-        if (speed > 2) target.kill((ServerLevel)target.level());
+        if (speed <= 2) {
+            return;
+        }
+        ServerLevel level = (ServerLevel) target.level();
+        if (target instanceof LivingEntity livingEntity) {
+            livingEntity.hurtServer(level, level.damageSources().flyIntoWall(), Float.MAX_VALUE);
+        } else {
+            target.kill(level);
+        }
     }
 }

--- a/src/main/java/com/kssjw/kineticminecart/util/CartImpactUtil.java
+++ b/src/main/java/com/kssjw/kineticminecart/util/CartImpactUtil.java
@@ -33,7 +33,7 @@ public class CartImpactUtil {
             damage = (float)Math.pow(speed, 2);
         } else return;
 
-        target.hurtServer((ServerLevel)world, world.damageSources().generic(), damage);  // 处刑
+        target.hurtServer((ServerLevel)world, world.damageSources().flyIntoWall(), damage);  // 处刑
     }
 
     public static void tryKill(Entity target, float speed) {


### PR DESCRIPTION
Since a new damage source cannot be added, I felt that the fly into wall source could work well. It reads `[mob] experienced kinetic energy`.